### PR TITLE
Add helper classes to parse and map CUSIP, Composite FIGI, SEDOL, ISIN

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,25 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Checkout Lean Same Branch
+        id: lean-same-branch
+        uses: actions/checkout@v2
+        continue-on-error: true
+        with:
+          ref: ${{ github.ref }}
+          repository: QuantConnect/Lean
+          path: Lean
+
+      - name: Checkout Lean Master
+        if: steps.lean-same-branch.outcome != 'success'
+        uses: actions/checkout@v2
+        with:
+          repository: QuantConnect/Lean
+          path: Lean
+
+      - name: Move Lean
+        run: mv Lean ../Lean
+
       - name: BuildDataSource
         run: dotnet build ./QuantConnect.DataSource.csproj /p:Configuration=Release /v:quiet /p:WarningLevel=1
 

--- a/QuantConnect.DataSource.csproj
+++ b/QuantConnect.DataSource.csproj
@@ -2,14 +2,17 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
+    <OutputPath>bin\$(Configuration)</OutputPath>
     <RootNamespace>QuantConnect.DataSource</RootNamespace>
+    
+    <!--Append your data source name to the end of `QuantConnect.DataSource` in the two lines below-->
+    <!--Example: `QuantConnect.DataSource.SDK`, `QuantConnect.DataSource.SDK.xml`-->
+    <AssemblyName>QuantConnect.DataSource</AssemblyName>
     <DocumentationFile>$(OutputPath)\QuantConnect.DataSource.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="QuantConnect.Common" Version="2.5.11800" />
     <PackageReference Include="protobuf-net" Version="3.0.29" />
-    <PackageReference Include="protobuf-net.Core" Version="3.0.29" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
@@ -22,6 +25,11 @@
     <None Remove="process.sample.ipynb" />
     <None Remove="process.sample.py" />
     <None Remove="process.sample.sh" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\Lean\Common\QuantConnect.csproj" />
+    <ProjectReference Include="..\Lean\Engine\QuantConnect.Lean.Engine.csproj" />
   </ItemGroup>
 
 </Project>

--- a/SDK/SecurityDefinition.cs
+++ b/SDK/SecurityDefinition.cs
@@ -1,0 +1,100 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace QuantConnect.DataSource.SDK
+{
+    /// <summary>
+    /// Helper class containing various unique identifiers for a given
+    /// <see cref="SecurityIdentifier"/>, such as FIGI, ISIN, CUSIP, SEDOL.
+    /// </summary>
+    public class SecurityDefinition
+    {
+        /// <summary>
+        /// The unique <see cref="SecurityIdentifier"/> identified by
+        /// the industry-standard security identifiers contained within this class.
+        /// </summary>
+        public SecurityIdentifier SecurityIdentifier { get; set; }
+        
+        /// <summary>
+        /// The CUSIP of the security
+        /// </summary>
+        public string CUSIP { get; set; }
+       
+        /// <summary>
+        /// The FIGI of the security
+        /// </summary>
+        public string FIGI { get; set; }
+        
+        /// <summary>
+        /// SEDOL of the security
+        /// </summary>
+        public string SEDOL { get; set; }
+       
+        /// <summary>
+        /// ISIN of the security
+        /// </summary>
+        public string ISIN { get; set; }
+        
+        /// <summary>
+        /// Reads data from the specified file and converts it to a list of SecurityDefinition
+        /// </summary>
+        /// <param name="securitiesFile">File to read from</param>
+        /// <returns>List of security definitions</returns>
+        public static List<SecurityDefinition> FromCsvFile(FileInfo securitiesFile)
+        {
+            return File.ReadAllLines(securitiesFile.FullName)
+                .Where(x => !string.IsNullOrWhiteSpace(x))
+                .Select(FromCsvLine)
+                .ToList();
+        }
+
+        public static bool TryFromCsvFile(FileInfo securitiesFile, out List<SecurityDefinition> securityDefinitions)
+        {
+            try
+            {
+                securityDefinitions = FromCsvFile(securitiesFile);
+                return true;
+            }
+            catch
+            {
+                securityDefinitions = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Parses a single line of CSV and converts it into an instance
+        /// </summary>
+        /// <param name="line">Line of CSV</param>
+        /// <returns>SecurityDefinition instance</returns>
+        public static SecurityDefinition FromCsvLine(string line)
+        {
+            var csv = line.Split(',');
+            return new SecurityDefinition
+            {
+                SecurityIdentifier = SecurityIdentifier.Parse(csv[0]),
+                CUSIP = string.IsNullOrWhiteSpace(csv[1]) ? null : csv[1],
+                FIGI = string.IsNullOrWhiteSpace(csv[2]) ? null : csv[2],
+                SEDOL = string.IsNullOrWhiteSpace(csv[3]) ? null : csv[3],
+                ISIN = string.IsNullOrWhiteSpace(csv[4]) ? null : csv[4]
+            };
+        }
+    }
+}

--- a/SDK/SecurityDefinitionSymbolResolver.cs
+++ b/SDK/SecurityDefinitionSymbolResolver.cs
@@ -1,0 +1,162 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using QuantConnect.Configuration;
+using QuantConnect.Data.Auxiliary;
+using QuantConnect.Interfaces;
+using QuantConnect.Lean.Engine.DataFeeds;
+using QuantConnect.Logging;
+using QuantConnect.Util;
+
+namespace QuantConnect.DataSource.SDK
+{
+    /// <summary>
+    /// Resolves standardized security definitions like FIGI, CUSIP, ISIN, etc. into Lean a Lean <see cref="Symbol"/>
+    /// </summary>
+    public class SecurityDefinitionSymbolResolver
+    {
+        private readonly List<SecurityDefinition> _securityDefinitions;
+        private readonly MapFileResolver _mapFileResolver;
+        
+        /// <summary>
+        /// Creates an instance of the symbol resolver
+        /// </summary>
+        /// <param name="dataFolder">Data folder to read the security-database.csv file from</param>
+        /// <param name="mapFileProvider">Map file provider used to obtain symbol mappings</param>
+        /// <param name="market">The market of the assets referred to by the security definitions</param>
+        public SecurityDefinitionSymbolResolver(
+            DirectoryInfo dataFolder = null,
+            IMapFileProvider mapFileProvider = null,
+            string market = Market.USA)
+        {
+            var dataFolderPath = dataFolder?.FullName ?? Globals.DataFolder;
+            
+            var securityDefinitionFile = new FileInfo(
+                Path.Combine(
+                    dataFolderPath,
+                    "symbol-properties",
+                    "security-database.csv"));            
+            
+            if (!SecurityDefinition.TryFromCsvFile(securityDefinitionFile, out _securityDefinitions))
+            {
+                Log.Error($"SecurityDefinitionSymbolResolver(): No security definitions data loaded from file: {securityDefinitionFile.FullName}");
+            }
+
+            if (mapFileProvider == null)
+            {
+                mapFileProvider = Composer.Instance.GetExportedValueByTypeName<IMapFileProvider>(Config.Get("map-file-provider", "LocalDiskMapFileProvider"));
+                mapFileProvider.Initialize(new DefaultDataProvider());
+            }
+            
+            _mapFileResolver = mapFileProvider.Get(market);
+        }
+        
+        /// <summary>
+        /// Converts CUSIP into a Lean <see cref="Symbol"/>
+        /// </summary>
+        /// <param name="cusip">CUSIP</param>
+        /// <param name="tradingDate">
+        /// The date that the stock was trading at with the CUSIP provided. This is used
+        /// to get the ticker of the symbol on this date.
+        /// </param>
+        /// <returns>The CUSIP's corresponding Symbol</returns>
+        public Symbol FromCUSIP(string cusip, DateTime tradingDate)
+        {
+            return SecurityDefinitionToSymbol(
+                _securityDefinitions?.FirstOrDefault(x => x.CUSIP == cusip && !string.IsNullOrWhiteSpace(x.CUSIP)),
+                tradingDate);
+        }
+        
+        /// <summary>
+        /// Converts FIGI into a Lean <see cref="Symbol"/>
+        /// </summary>
+        /// <param name="compositeFigi">Composite FIGI</param>
+        /// <param name="tradingDate">
+        /// The date that the stock was trading at with the composite FIGI provided. This is used
+        /// to get the ticker of the symbol on this date.
+        /// </param>
+        /// <returns>The composite FIGI's corresponding Symbol</returns>
+        public Symbol FromCompositeFIGI(string compositeFigi, DateTime tradingDate)
+        {
+            return SecurityDefinitionToSymbol(
+                _securityDefinitions?.FirstOrDefault(x => x.FIGI == compositeFigi && !string.IsNullOrWhiteSpace(x.FIGI)),
+                tradingDate);
+        }
+        
+        /// <summary>
+        /// Converts SEDOL into a Lean <see cref="Symbol"/>
+        /// </summary>
+        /// <param name="sedol">SEDOL</param>
+        /// <param name="tradingDate">
+        /// The date that the stock was trading at with the SEDOL provided. This is used
+        /// to get the ticker of the symbol on this date.
+        /// </param>
+        /// <returns>The SEDOL's corresponding Symbol</returns>
+        public Symbol FromSEDOL(string sedol, DateTime tradingDate)
+        {
+            return SecurityDefinitionToSymbol(
+                _securityDefinitions?.FirstOrDefault(x => x.SEDOL == sedol && !string.IsNullOrWhiteSpace(x.SEDOL)),
+                tradingDate);
+        }
+
+        /// <summary>
+        /// Converts ISIN into a Lean <see cref="Symbol"/>
+        /// </summary>
+        /// <param name="isin">ISIN</param>
+        /// <param name="tradingDate">
+        /// The date that the stock was trading at with the ISIN provided. This is used
+        /// to get the ticker of the symbol on this date.
+        /// </param>
+        /// <returns>The ISIN's corresponding Lean Symbol</returns>
+        public Symbol FromISIN(string isin, DateTime tradingDate)
+        {
+            return SecurityDefinitionToSymbol(
+                _securityDefinitions?.FirstOrDefault(x => x.ISIN == isin),
+                tradingDate);
+        }
+
+        /// <summary>
+        /// Converts a SecurityDefinition to a <see cref="Symbol" />
+        /// </summary>
+        /// <param name="securityDefinition">Security definition</param>
+        /// <param name="tradingDate">
+        /// The date that the stock was being traded. This is used to resolve
+        /// the ticker that the stock was trading under on this date.
+        /// </param>
+        /// <returns>Symbol if matching Lean Symbol was found on the trading date, null otherwise</returns>
+        private Symbol SecurityDefinitionToSymbol(SecurityDefinition securityDefinition, DateTime tradingDate)
+        {
+            if (securityDefinition == null)
+            {
+                return null;
+            }
+            
+            // Get the first ticker the symbol traded under, and then lookup the
+            // trading date to get the ticker on the trading date.
+            var mappedTicker = _mapFileResolver
+                .ResolveMapFile(securityDefinition.SecurityIdentifier.Symbol, securityDefinition.SecurityIdentifier.Date)
+                .GetMappedSymbol(tradingDate);
+
+            return string.IsNullOrWhiteSpace(mappedTicker) 
+                ? null 
+                : new Symbol(securityDefinition.SecurityIdentifier, mappedTicker);
+        }
+    }
+}

--- a/tests/SDK/SecurityDefinitionSymbolResolverTests.cs
+++ b/tests/SDK/SecurityDefinitionSymbolResolverTests.cs
@@ -1,0 +1,227 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using NUnit.Framework;
+using QuantConnect.Configuration;
+using QuantConnect.DataSource.SDK;
+
+namespace QuantConnect.DataLibrary.Tests.SDK
+{
+    [TestFixture]
+    public class SecurityDefinitionSymbolResolverTests
+    {
+        private string _dataFolderConfig;
+        private DirectoryInfo _testingDataDirectory;
+        private SecurityDefinitionSymbolResolver _instance;
+        private static readonly Dictionary<string, string> _tickerToSecurityIdentifier = new Dictionary<string, string>
+        {
+            {"AAPL", "AAPL R735QTJ8XC9X"},
+            {"GOOG", "GOOCV VP83T1ZUHROL"},
+            {"GOOCV", "GOOCV VP83T1ZUHROL"},
+            {"QQQ", "QQQ RIWIV7K5Z9LX"},
+            {"QQQQ", "QQQ RIWIV7K5Z9LX"}
+        };
+
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            _testingDataDirectory = Directory.CreateDirectory(Path.Combine(Directory.GetCurrentDirectory(), "testing_data"));
+            _dataFolderConfig = Globals.DataFolder;
+            
+            Config.Set("data-folder", "../../../../../Lean/Data");
+            Globals.Reset();
+            
+            var symbolPropertiesDirectory = Directory.CreateDirectory(Path.Combine(_testingDataDirectory.FullName, "symbol-properties"));
+            var securityDatabaseLines = string.Join("\n", new[]
+            {
+                "AAPL R735QTJ8XC9X,03783310,BBG000B9XRY4,2046251,US0378331005",
+                "GOOG T1AZ164W5VTX,38259P50,BBG000BHSKN9,B020QX2,US38259P5089",
+                "GOOCV VP83T1ZUHROL,38259P70,BBG002W96FT9,BKM4JZ7,US38259P7069",
+                "QQQ RIWIV7K5Z9LX,73935A10,BBG000BSWKH7,BDQYP67,US46090E1038"
+            });
+
+            File.WriteAllText(
+                Path.Combine(symbolPropertiesDirectory.FullName, "security-database.csv"),
+                securityDatabaseLines);
+
+            // Initialize the resolver now that we have data
+            _instance = new SecurityDefinitionSymbolResolver(_testingDataDirectory);
+        }
+
+        [OneTimeTearDown]
+        public void TearDown()
+        {
+            _testingDataDirectory.Delete(true);
+            
+            Config.Set("data-folder", _dataFolderConfig);
+            Globals.Reset();
+        }
+        
+        [TestCase("03783310", 2021, 9, 9, "AAPL", Market.USA)]
+        [TestCase("03783310", 2002, 9, 9, "AAPL", Market.USA)]
+        [TestCase("03783310", 1995, 1, 1, "AAPL", Market.USA)]
+        [TestCase("38259P70", 2021, 9, 9, "GOOG", Market.USA)]
+        [TestCase("38259P70", 2014, 4, 3, "GOOG", Market.USA)]
+        [TestCase("38259P70", 2014, 4, 2, "GOOCV", Market.USA)]
+        [TestCase("38259P70", 2014, 3, 10, "GOOCV", Market.USA)]
+        [TestCase("38259P70", 2014, 3, 28, "GOOCV", Market.USA)]
+        [TestCase("38259P70", 2014, 3, 27, "GOOCV", Market.USA)]
+        [TestCase("73935A10", 2021, 9, 9, "QQQ", Market.USA)]
+        [TestCase("73935A10", 2012, 12, 21, "QQQ", Market.USA)]
+        [TestCase("73935A10", 2011, 3, 23, "QQQ", Market.USA)]
+        [TestCase("73935A10", 2011, 3, 22, "QQQQ", Market.USA)]
+        [TestCase("73935A10", 2011, 3, 21, "QQQQ", Market.USA)]
+        [TestCase("73935A10", 2005, 1, 1, "QQQQ", Market.USA)]
+        [TestCase("73935A10", 2004, 12, 1, "QQQQ", Market.USA)]
+        [TestCase("73935A10", 2004, 11, 30, "QQQ", Market.USA)]
+        [TestCase("73935A10", 2004, 11, 29, "QQQ", Market.USA)]
+        [TestCase("73935A10", 1999, 5, 21, "QQQ", Market.USA)]
+        [TestCase("73935A10", 1999, 3, 11, "QQQ", Market.USA)]
+        [TestCase("73935A10", 1999, 3, 10, "QQQ", Market.USA)]
+        [TestCase("73935A10", 1998, 5, 21, "QQQ", Market.USA)]
+        [TestCase("", 2021, 9, 9, null, Market.USA)]
+        [TestCase("ABCDEF99", 2021, 9, 9, null, Market.USA)]
+        [TestCase(null, 2021, 9, 9, null, Market.USA)]
+        [TestCase("1", 2021, 9, 9, null, Market.USA)]
+        public void ResolvesCUSIP(string cusip, int year, int month, int day, string expectedTicker, string expectedMarket)
+        {
+            var tradingDate = new DateTime(year, month, day);
+            var expectedSid = expectedTicker == null
+                ? null
+                : _tickerToSecurityIdentifier[expectedTicker];
+            
+            AssertSymbol(_instance.FromCUSIP(cusip, tradingDate), expectedTicker, expectedSid, expectedMarket);
+        }
+        
+        [TestCase("BBG000B9XRY4", 2021, 9, 9, "AAPL", Market.USA)]
+        [TestCase("BBG000B9XRY4", 2002, 9, 9, "AAPL", Market.USA)]
+        [TestCase("BBG000B9XRY4", 1995, 1, 1, "AAPL", Market.USA)]
+        [TestCase("BBG002W96FT9", 2021, 9, 9, "GOOG", Market.USA)]
+        [TestCase("BBG002W96FT9", 2014, 4, 3, "GOOG", Market.USA)]
+        [TestCase("BBG002W96FT9", 2014, 4, 2, "GOOCV", Market.USA)]
+        [TestCase("BBG002W96FT9", 2014, 3, 10, "GOOCV", Market.USA)]
+        [TestCase("BBG002W96FT9", 2014, 3, 28, "GOOCV", Market.USA)]
+        [TestCase("BBG002W96FT9", 2014, 3, 27, "GOOCV", Market.USA)]
+        [TestCase("BBG000BSWKH7", 2021, 9, 9, "QQQ", Market.USA)]
+        [TestCase("BBG000BSWKH7", 2012, 12, 21, "QQQ", Market.USA)]
+        [TestCase("BBG000BSWKH7", 2011, 3, 23, "QQQ", Market.USA)]
+        [TestCase("BBG000BSWKH7", 2011, 3, 22, "QQQQ", Market.USA)]
+        [TestCase("BBG000BSWKH7", 2011, 3, 21, "QQQQ", Market.USA)]
+        [TestCase("BBG000BSWKH7", 2005, 1, 1, "QQQQ", Market.USA)]
+        [TestCase("BBG000BSWKH7", 2004, 12, 1, "QQQQ", Market.USA)]
+        [TestCase("BBG000BSWKH7", 2004, 11, 30, "QQQ", Market.USA)]
+        [TestCase("BBG000BSWKH7", 2004, 11, 29, "QQQ", Market.USA)]
+        [TestCase("BBG000BSWKH7", 1999, 5, 21, "QQQ", Market.USA)]
+        [TestCase("BBG000BSWKH7", 1999, 3, 11, "QQQ", Market.USA)]
+        [TestCase("BBG000BSWKH7", 1999, 3, 10, "QQQ", Market.USA)]
+        [TestCase("BBG000BSWKH7", 1998, 5, 21, "QQQ", Market.USA)]
+        [TestCase("", 2021, 9, 9, null, Market.USA)]
+        [TestCase("ABCDEF99", 2021, 9, 9, null, Market.USA)]
+        [TestCase(null, 2021, 9, 9, null, Market.USA)]
+        [TestCase("1", 2021, 9, 9, null, Market.USA)]
+        public void ResolvesCompositeFIGI(string compositeFigi, int year, int month, int day, string expectedTicker, string expectedMarket)
+        {
+            var tradingDate = new DateTime(year, month, day);
+            var expectedSid = expectedTicker == null
+                ? null
+                : _tickerToSecurityIdentifier[expectedTicker];
+            
+            AssertSymbol(_instance.FromCompositeFIGI(compositeFigi, tradingDate), expectedTicker, expectedSid, expectedMarket);
+        }
+        
+        [TestCase("2046251", 2021, 9, 9, "AAPL", Market.USA)]
+        [TestCase("2046251", 2002, 9, 9, "AAPL", Market.USA)]
+        [TestCase("2046251", 1995, 1, 1, "AAPL", Market.USA)]
+        [TestCase("BKM4JZ7", 2021, 9, 9, "GOOG", Market.USA)]
+        [TestCase("BKM4JZ7", 2014, 4, 3, "GOOG", Market.USA)]
+        [TestCase("BKM4JZ7", 2014, 4, 2, "GOOCV", Market.USA)]
+        [TestCase("BKM4JZ7", 2014, 3, 10, "GOOCV", Market.USA)]
+        [TestCase("BKM4JZ7", 2014, 3, 28, "GOOCV", Market.USA)]
+        [TestCase("BKM4JZ7", 2014, 3, 27, "GOOCV", Market.USA)]
+        [TestCase("BDQYP67", 2021, 9, 9, "QQQ", Market.USA)]
+        [TestCase("BDQYP67", 2012, 12, 21, "QQQ", Market.USA)]
+        [TestCase("BDQYP67", 2011, 3, 23, "QQQ", Market.USA)]
+        [TestCase("BDQYP67", 2011, 3, 22, "QQQQ", Market.USA)]
+        [TestCase("BDQYP67", 2011, 3, 21, "QQQQ", Market.USA)]
+        [TestCase("BDQYP67", 2005, 1, 1, "QQQQ", Market.USA)]
+        [TestCase("BDQYP67", 2004, 12, 1, "QQQQ", Market.USA)]
+        [TestCase("BDQYP67", 2004, 11, 30, "QQQ", Market.USA)]
+        [TestCase("BDQYP67", 2004, 11, 29, "QQQ", Market.USA)]
+        [TestCase("BDQYP67", 1999, 5, 21, "QQQ", Market.USA)]
+        [TestCase("BDQYP67", 1999, 3, 11, "QQQ", Market.USA)]
+        [TestCase("BDQYP67", 1999, 3, 10, "QQQ", Market.USA)]
+        [TestCase("BDQYP67", 1998, 5, 21, "QQQ", Market.USA)]
+        [TestCase("", 2021, 9, 9, null, Market.USA)]
+        [TestCase("ABCDEF99", 2021, 9, 9, null, Market.USA)]
+        [TestCase(null, 2021, 9, 9, null, Market.USA)]
+        [TestCase("1", 2021, 9, 9, null, Market.USA)]
+        public void ResolvesSEDOL(string sedol, int year, int month, int day, string expectedTicker, string expectedMarket)
+        {
+            var tradingDate = new DateTime(year, month, day);
+            var expectedSid = expectedTicker == null
+                ? null
+                : _tickerToSecurityIdentifier[expectedTicker];
+            
+            AssertSymbol(_instance.FromSEDOL(sedol, tradingDate), expectedTicker, expectedSid, expectedMarket);
+        }
+        
+        [TestCase("US0378331005", 2021, 9, 9, "AAPL", Market.USA)]
+        [TestCase("US0378331005", 2002, 9, 9, "AAPL", Market.USA)]
+        [TestCase("US0378331005", 1995, 1, 1, "AAPL", Market.USA)]
+        [TestCase("US38259P7069", 2021, 9, 9, "GOOG", Market.USA)]
+        [TestCase("US38259P7069", 2014, 4, 3, "GOOG", Market.USA)]
+        [TestCase("US38259P7069", 2014, 4, 2, "GOOCV", Market.USA)]
+        [TestCase("US38259P7069", 2014, 3, 10, "GOOCV", Market.USA)]
+        [TestCase("US38259P7069", 2014, 3, 28, "GOOCV", Market.USA)]
+        [TestCase("US38259P7069", 2014, 3, 27, "GOOCV", Market.USA)]
+        [TestCase("US46090E1038", 2021, 9, 9, "QQQ", Market.USA)]
+        [TestCase("US46090E1038", 2012, 12, 21, "QQQ", Market.USA)]
+        [TestCase("US46090E1038", 2011, 3, 23, "QQQ", Market.USA)]
+        [TestCase("US46090E1038", 2011, 3, 22, "QQQQ", Market.USA)]
+        [TestCase("US46090E1038", 2011, 3, 21, "QQQQ", Market.USA)]
+        [TestCase("US46090E1038", 2005, 1, 1, "QQQQ", Market.USA)]
+        [TestCase("US46090E1038", 2004, 12, 1, "QQQQ", Market.USA)]
+        [TestCase("US46090E1038", 2004, 11, 30, "QQQ", Market.USA)]
+        [TestCase("US46090E1038", 2004, 11, 29, "QQQ", Market.USA)]
+        [TestCase("US46090E1038", 1999, 5, 21, "QQQ", Market.USA)]
+        [TestCase("US46090E1038", 1999, 3, 11, "QQQ", Market.USA)]
+        [TestCase("US46090E1038", 1999, 3, 10, "QQQ", Market.USA)]
+        [TestCase("US46090E1038", 1998, 5, 21, "QQQ", Market.USA)]
+        [TestCase("", 2021, 9, 9, null, Market.USA)]
+        [TestCase("ABCDEF99", 2021, 9, 9, null, Market.USA)]
+        [TestCase(null, 2021, 9, 9, null, Market.USA)]
+        [TestCase("1", 2021, 9, 9, null, Market.USA)]
+        public void ResolvesISIN(string isin, int year, int month, int day, string expectedTicker, string expectedMarket)
+        {
+            var tradingDate = new DateTime(year, month, day);
+            var expectedSid = expectedTicker == null
+                ? null
+                : _tickerToSecurityIdentifier[expectedTicker];
+            
+            AssertSymbol(_instance.FromISIN(isin, tradingDate), expectedTicker, expectedSid, expectedMarket);
+        }
+
+        private void AssertSymbol(Symbol actual, string expectedTicker, string expectedSid, string expectedMarket)
+        {
+            Assert.AreEqual(expectedTicker, actual?.Value);
+            Assert.AreEqual(expectedSid, actual?.ID.ToString());
+            Assert.AreEqual(expectedMarket, actual?.ID.Market ?? expectedMarket);
+        }
+    }
+}

--- a/tests/SDK/SecurityDefinitionTests.cs
+++ b/tests/SDK/SecurityDefinitionTests.cs
@@ -1,0 +1,60 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using System;
+using NUnit.Framework;
+using QuantConnect.DataSource.SDK;
+
+namespace QuantConnect.DataLibrary.Tests.SDK
+{
+    [TestFixture]
+    public class SecurityDefinitionTests
+    {
+        [TestCase("AAPL R735QTJ8XC9X,03783310,BBG000B9XRY4,2046251,US0378331005", "03783310", "BBG000B9XRY4", "2046251", "US0378331005")]
+        [TestCase("GOOG T1AZ164W5VTX,38259P50,BBG000BHSKN9,B020QX2,US38259P5089", "38259P50", "BBG000BHSKN9", "B020QX2", "US38259P5089")]
+        [TestCase("MXA R735QTJ8XC9X,,BBG000BFDB59,,US6040621095", null, "BBG000BFDB59", null, "US6040621095")]
+        [TestCase("MXA R735QTJ8XC9X,60406210,,,US6040621095", "60406210", null, null, "US6040621095")]
+        [TestCase("MXA R735QTJ8XC9X,60406210,BBG000BFDB59,,US6040621095", "60406210", "BBG000BFDB59", null, "US6040621095")]
+        [TestCase("MXA R735QTJ8XC9X,60406210,BBG000BFDB59,,", "60406210", "BBG000BFDB59", null, null)]
+        
+        public void ParsesCSV(string line, string cusipExpected, string figiExpected, string sedolExpected, string isinExpected)
+        {
+            var securityDefinition = SecurityDefinition.FromCsvLine(line);
+            
+            Assert.AreEqual(cusipExpected, securityDefinition.CUSIP);
+            Assert.AreEqual(figiExpected, securityDefinition.FIGI);
+            Assert.AreEqual(sedolExpected, securityDefinition.SEDOL);
+            Assert.AreEqual(isinExpected, securityDefinition.ISIN);
+        }
+
+        [TestCase("MXA ABCDEFGHIJKL,60406210,BBG000BFDB59,,US6040621095")]
+        [TestCase("60406210,BBG000BFDB59,,US6040621095")]
+        [TestCase("MXA R735QTJ8XC9X,60406210,BBG000BFDB59,")]
+        [TestCase("MXA R735QTJ8XC9X")]
+        [TestCase("")]
+        public void DoesNotParseCSV(string line)
+        {
+            try
+            {
+                var lines = SecurityDefinition.FromCsvLine(line);
+                Assert.Fail($"Successfully read line when expecting failure: {line}");
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/tests/Tests.csproj
+++ b/tests/Tests.csproj
@@ -1,23 +1,27 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>QuantConnect.DataLibrary.Tests</RootNamespace>
   </PropertyGroup>
+  
   <ItemGroup>
     <Compile Include="..\Demonstration.cs" Link="Demonstration.cs" />
   </ItemGroup>
+  
   <ItemGroup>
     <PackageReference Include="protobuf-net" Version="3.0.29" />
-    <PackageReference Include="protobuf-net.Core" Version="3.0.29" />
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.9.4" />
-    <PackageReference Include="QuantConnect.Algorithm" Version="2.5.11800" />
   </ItemGroup>
+  
   <ItemGroup>
     <ProjectReference Include="..\QuantConnect.DataSource.csproj" />
+    <ProjectReference Include="..\..\Lean\Algorithm\QuantConnect.Algorithm.csproj" />
   </ItemGroup>
+  
 </Project>


### PR DESCRIPTION
I cleaned up the project a bit to remove unwanted extra dependencies, and I added some instructions to the csproj file to clarify what changes need to be made to it.

I'm making the Lean project include a relative path vs. NuGet package, since the NuGet package isn't updated on every push.

Adds tests for new helper class

Note: include to `QuantConnect.Lean.Engine.DataFeeds` was required to import `DefaultDataProvider`