### PR TITLE
Upgrade to .NET 6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,4 +40,4 @@ jobs:
         run: dotnet build ./tests/Tests.csproj /p:Configuration=Release /v:quiet /p:WarningLevel=1
 
       - name: Run Tests
-        run: dotnet test ./tests/bin/Release/net5.0/Tests.dll
+        run: dotnet test ./tests/bin/Release/net6.0/Tests.dll

--- a/DataProcessing/DataProcessing.csproj
+++ b/DataProcessing/DataProcessing.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <AssemblyName>process</AssemblyName>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     </PropertyGroup>

--- a/QuantConnect.DataSource.csproj
+++ b/QuantConnect.DataSource.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>QuantConnect.DataSource</RootNamespace>
     <AssemblyName>QuantConnect.DataSource.MyCustomDataType</AssemblyName>
     <OutputPath>bin\$(Configuration)</OutputPath>

--- a/tests/Tests.csproj
+++ b/tests/Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>QuantConnect.DataLibrary.Tests</RootNamespace>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Note: the project doesn't build on GitHub CI because it uses `quantconnect/lean:foundation` which doesn't have .NET 6 SDK yet.
The project builds and the unit tests pass locally:
```
base) PS C:\Users\Alex\Lean.DataSource.SDK\tests> dotnet build .\Tests.csproj
Microsoft (R) Build Engine version 17.1.1+a02f73656 for .NET
Copyright (C) Microsoft Corporation. All rights reserved.

  Determining projects to restore...
  Restored C:\Users\Alex\Lean.DataSource.SDK\tests\Tests.csproj (in 925 ms).
  1 of 2 projects are up-to-date for restore.
  QuantConnect.DataSource -> C:\Users\Alex\Lean.DataSource.SDK\bin\Debug\net6.0\QuantConnect.DataSource.MyCustomDataType.dll
  Tests -> C:\Users\Alex\Lean.DataSource.SDK\tests\bin\Debug\net6.0\Tests.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:02.86
(base) PS C:\Users\Alex\Lean.DataSource.SDK\tests> dotnet test .\bin\Debug\net6.0\Tests.dll
Microsoft (R) Test Execution Command Line Tool Version 17.1.0
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...
A total of 1 test files matched the specified pattern.
20220429 23:11:28.897 TRACE:: Config.Get(): Configuration key not found. Key: map-file-provider - Using default value: LocalDiskMapFileProvider


Passed!  - Failed:     0, Passed:     3, Skipped:     0, Total:     3, Duration: 464 ms - Tests.dll (net6.0)
```