### PR TITLE
Use process.runtimeconfig.json to Set Runtime in CLRImports Module

### DIFF
--- a/DataProcessing/CLRImports.py
+++ b/DataProcessing/CLRImports.py
@@ -1,24 +1,11 @@
 # This file is used to import the environment and classes/methods of LEAN.
 # so that any python file could be using LEAN's classes/methods.
-
-from os import remove
-from json import dump
 from clr_loader import get_coreclr
 from pythonnet import set_runtime
 
-with open('tmp.json', 'w') as fp:
-    dump({
-            "runtimeOptions": {
-                "tfm": "net5.0",
-                "framework": {
-                    "name": "Microsoft.NETCore.App",
-                    "version": "5.0.0"
-                 }
-             }
-         },
-        fp, ensure_ascii=True, indent=4)
-set_runtime(get_coreclr('tmp.json'))
-remove('tmp.json')
+# process.runtimeconfig.json is created when we build the DataProcessing Project:
+# dotnet build .\DataProcessing\DataProcessing.csproj
+set_runtime(get_coreclr('process.runtimeconfig.json'))
 
 from AlgorithmImports import *
 from QuantConnect.Lean.Engine.DataFeeds import *


### PR DESCRIPTION
After building the DataProcessing Project, I performed the following test:
```
Lean.DataSource.SDK\DataProcessing\bin\Debug\net6.0> python .\CLRImports.py
PythonEngine.Initialize(): clr GetManifestResourceStream...
```
showing that the `process.runtimeconfig.json` was read successfully.