### PR TITLE
Feature: multiple subscription generic test cases

### DIFF
--- a/MyCustomDataProvider.cs
+++ b/MyCustomDataProvider.cs
@@ -28,7 +28,7 @@ namespace QuantConnect.Lean.DataSource.MyCustom
     /// <summary>
     /// Implementation of Custom Data Provider
     /// </summary>
-    public class MyCustomDataProvider : SynchronizingHistoryProvider, IDataQueueHandler
+    public class MyCustomDataProvider : SynchronizingHistoryProvider, IDataQueueHandler, IDataQueueUniverseProvider
     {
         /// <summary>
         /// <inheritdoc cref="IDataAggregator"/>
@@ -155,6 +155,21 @@ namespace QuantConnect.Lean.DataSource.MyCustom
                 return false;
             }
 
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<Symbol> LookupSymbols(Symbol symbol, bool includeExpired, string securityCurrency = null)
+        {
+            if (!symbol.SecurityType.IsOption())
+            {
+                throw new ArgumentException($"Unsupported security type: {symbol.SecurityType}", nameof(symbol));
+            }
+
+            throw new NotImplementedException();
+        }
+
+        public bool CanPerformSelection()
+        {
             throw new NotImplementedException();
         }
     }


### PR DESCRIPTION
- Implement `interface IDataQueueUniverseProvider` in `class MyCustomDataProvider`
- Generic test to subscribe to all option chains by underlying to test the subscription on a huge range of symbols.