### PR TITLE
Add WilsonJerez.ExampleDataset demo folder with README

### DIFF
--- a/DataSource/WilsonJerez.ExampleDataset/README.md
+++ b/DataSource/WilsonJerez.ExampleDataset/README.md
@@ -1,0 +1,4 @@
+Author: Wilson Eduardo Jerez Hernández
+
+This is a minimal demo using the Lean Data Source SDK template.
+It documents how a `BaseData` dataset would be wired: `GetSource`, `Reader`, and `Clone`.


### PR DESCRIPTION
Minimal Data SDK demo for QuantConnect internship.

Adds `DataSource/WilsonJerez.ExampleDataset/README.md`
showing understanding of the Data SDK template structure.
Documents the intended `BaseData` workflow (GetSource, Reader, Clone).

I can expand with a working C# class if required. Thanks!
