### PR TITLE
Run CI on self-hosted runners

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,17 +1,9 @@
 name: Setup
-description: Liberate disk space, checkout Lean, pull foundation image, define docker helper
+description: Checkout Lean
 
 runs:
   using: composite
   steps:
-    - name: Liberate disk space
-      uses: jlumbroso/free-disk-space@main
-      with:
-        tool-cache: true
-        large-packages: false
-        docker-images: false
-        swap-storage: false
-
     - name: Check if Lean has same branch
       id: lean-branch-check
       run: |
@@ -41,14 +33,4 @@ runs:
 
     - name: Move Lean
       run: mv Lean ../Lean
-      shell: bash
-
-    - name: Pull foundation image
-      run: docker pull quantconnect/lean:foundation
-      shell: bash
-
-    - name: Define docker helper
-      run: |
-        echo 'runInContainer() { docker exec test-container "$@"; }' > $HOME/ci_functions.sh
-        echo "BASH_ENV=$HOME/ci_functions.sh" >> $GITHUB_ENV
       shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,9 +6,16 @@ on:
   pull_request:
     branches: [master]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: self-hosted
+    container:
+        image: quantconnect/lean:foundation
+        options: --cpus 12 --memory 12g
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -19,50 +26,38 @@ jobs:
       - name: Copy sample data to LEAN Data folder
         run: cp -r ../Lean.DataSource.SDK/output/* ../Lean/Data/
 
-      - name: Start container
-        run: |
-          docker run -d \
-            --workdir /__w/Lean.DataSource.SDK/Lean.DataSource.SDK \
-            -v /home/runner/work:/__w \
-            --name test-container \
-            quantconnect/lean:foundation \
-            tail -f /dev/null
-
       - name: Build DataSource
-        run: runInContainer dotnet build ./QuantConnect.DataSource.csproj /p:Configuration=Release /v:quiet /p:WarningLevel=1
+        run: dotnet build ./QuantConnect.DataSource.csproj /p:Configuration=Release /v:quiet /p:WarningLevel=1
 
       - name: Build Tests
-        run: runInContainer dotnet build ./tests/Tests.csproj /p:Configuration=Release /v:quiet /p:WarningLevel=1
+        run: dotnet build ./tests/Tests.csproj /p:Configuration=Release /v:quiet /p:WarningLevel=1
 
       - name: Run Tests
-        run: runInContainer dotnet test ./tests/bin/Release/net10.0/Tests.dll
+        run: dotnet test ./tests/bin/Release/net10.0/Tests.dll
 
       - name: Build LEAN Launcher
-        run: runInContainer dotnet build ../Lean/Launcher/QuantConnect.Lean.Launcher.csproj /p:Configuration=Release /p:OutputPath=bin/Release /v:quiet /p:WarningLevel=1
+        run: dotnet build ../Lean/Launcher/QuantConnect.Lean.Launcher.csproj /p:Configuration=Release /p:OutputPath=bin/Release /v:quiet /p:WarningLevel=1
 
       - name: Copy DataSource to LEAN Launcher
-        run: runInContainer cp ./tests/bin/Release/net10.0/QuantConnect.DataSource.MyCustomDataType.dll ../Lean/Launcher/bin/Release/
+        run: cp ./tests/bin/Release/net10.0/QuantConnect.DataSource.MyCustomDataType.dll ../Lean/Launcher/bin/Release/
 
       - name: Run C# Demo Algorithm
         run: |
-          output=$(runInContainer bash -c "cd ../Lean/Launcher/bin/Release && dotnet ./QuantConnect.Lean.Launcher.dll --data-folder /__w/Lean.DataSource.SDK/Lean/Data/ --algorithm-language CSharp --algorithm-type-name CustomDataAlgorithm --algorithm-location /__w/Lean.DataSource.SDK/Lean.DataSource.SDK/tests/bin/Release/net10.0/Tests.dll --close-automatically true" 2>&1)
+          output=$(bash -c "cd ../Lean/Launcher/bin/Release && dotnet ./QuantConnect.Lean.Launcher.dll --data-folder /__w/Lean.DataSource.SDK/Lean/Data/ --algorithm-language CSharp --algorithm-type-name CustomDataAlgorithm --algorithm-location /__w/Lean.DataSource.SDK/Lean.DataSource.SDK/tests/bin/Release/net10.0/Tests.dll --close-automatically true" 2>&1)
           echo "$output"
           echo "$output" | grep -q "STATISTICS:: Total Orders [^0]" || { echo "Algorithm placed no trades"; exit 1; }
 
       - name: Run Python Demo Algorithm
         run: |
-          output=$(runInContainer bash -c 'cd ../Lean/Launcher/bin/Release && dotnet ./QuantConnect.Lean.Launcher.dll --data-folder /__w/Lean.DataSource.SDK/Lean/Data/ --algorithm-language Python --algorithm-type-name CustomDataAlgorithm --algorithm-location /__w/Lean.DataSource.SDK/Lean.DataSource.SDK/Demonstration.py --close-automatically true' 2>&1) || true
+          output=$(bash -c 'cd ../Lean/Launcher/bin/Release && dotnet ./QuantConnect.Lean.Launcher.dll --data-folder /__w/Lean.DataSource.SDK/Lean/Data/ --algorithm-language Python --algorithm-type-name CustomDataAlgorithm --algorithm-location /__w/Lean.DataSource.SDK/Lean.DataSource.SDK/Demonstration.py --close-automatically true' 2>&1) || true
           echo "$output"
           echo "$output" | grep -q "STATISTICS:: Total Orders [^0]" || { echo "Algorithm placed no trades"; exit 1; }
 
       - name: Run C# Universe Demo Algorithm
-        run: runInContainer bash -c "cd ../Lean/Launcher/bin/Release && dotnet ./QuantConnect.Lean.Launcher.dll --data-folder /__w/Lean.DataSource.SDK/Lean/Data/ --algorithm-language CSharp --algorithm-type-name CustomDataUniverse --algorithm-location /__w/Lean.DataSource.SDK/Lean.DataSource.SDK/tests/bin/Release/net10.0/Tests.dll --close-automatically true"
+        run: bash -c "cd ../Lean/Launcher/bin/Release && dotnet ./QuantConnect.Lean.Launcher.dll --data-folder /__w/Lean.DataSource.SDK/Lean/Data/ --algorithm-language CSharp --algorithm-type-name CustomDataUniverse --algorithm-location /__w/Lean.DataSource.SDK/Lean.DataSource.SDK/tests/bin/Release/net10.0/Tests.dll --close-automatically true"
 
       - name: Run Python Universe Demo Algorithm
-        run: runInContainer bash -c 'cd ../Lean/Launcher/bin/Release && dotnet ./QuantConnect.Lean.Launcher.dll --data-folder /__w/Lean.DataSource.SDK/Lean/Data/ --algorithm-language Python --algorithm-type-name CustomDataUniverse --algorithm-location /__w/Lean.DataSource.SDK/Lean.DataSource.SDK/DemonstrationUniverse.py --close-automatically true || [ $? -eq 134 ]'
-
-      - name: Stop container
-        run: docker rm -f test-container
+        run: bash -c 'cd ../Lean/Launcher/bin/Release && dotnet ./QuantConnect.Lean.Launcher.dll --data-folder /__w/Lean.DataSource.SDK/Lean/Data/ --algorithm-language Python --algorithm-type-name CustomDataUniverse --algorithm-location /__w/Lean.DataSource.SDK/Lean.DataSource.SDK/DemonstrationUniverse.py --close-automatically true || [ $? -eq 134 ]'
 
   rename:
     needs: build

--- a/.github/workflows/rename-build.yml
+++ b/.github/workflows/rename-build.yml
@@ -6,7 +6,10 @@ on:
 jobs:
   rename-build:
     if: github.repository == 'QuantConnect/Lean.DataSource.SDK'
-    runs-on: ubuntu-24.04
+    runs-on: self-hosted
+    container:
+        image: quantconnect/lean:foundation
+        options: --cpus 12 --memory 12g
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -20,20 +23,11 @@ jobs:
           cd ../Lean.DataSource.Rename
           python renameDataset.py Rename Dataset
 
-      - name: Start container (renamed)
-        run: |
-          docker run -d \
-            --workdir /__w/Lean.DataSource.SDK/Lean.DataSource.Rename \
-            -v /home/runner/work:/__w \
-            --name test-container \
-            quantconnect/lean:foundation \
-            tail -f /dev/null
-
       - name: Build Renamed DataSource
-        run: runInContainer dotnet build ./QuantConnect.DataSource.csproj /p:Configuration=Release /v:quiet /p:WarningLevel=1
+        run: cd ../Lean.DataSource.Rename && dotnet build ./QuantConnect.DataSource.csproj /p:Configuration=Release /v:quiet /p:WarningLevel=1
 
       - name: Build Renamed Tests
-        run: runInContainer dotnet build ./tests/Tests.csproj /p:Configuration=Release /v:quiet /p:WarningLevel=1
+        run: cd ../Lean.DataSource.Rename && dotnet build ./tests/Tests.csproj /p:Configuration=Release /v:quiet /p:WarningLevel=1
 
       - name: Run Renamed Tests
-        run: runInContainer dotnet test ./tests/bin/Release/net10.0/Tests.dll
+        run: cd ../Lean.DataSource.Rename && dotnet test ./tests/bin/Release/net10.0/Tests.dll


### PR DESCRIPTION
Mirrors QuantConnect/Lean#9540 (`c57fd18b`). This repo used the manual `docker run --name test-container` + `runInContainer` template (via the composite `Setup` action), which can't run on self-hosted runners (no docker).

- **build.yml / rename-build.yml**: `runs-on: self-hosted` inside a job-level `quantconnect/lean:foundation` container (`--cpus 12 --memory 12g`); removed the Start/Stop `test-container` steps; stripped `runInContainer` from every command (they run directly in the container); `rename-build` `cd`s into the renamed copy per step (the job container's workdir is the repo root). `build.yml` adds a `concurrency` group.
- **actions/setup** composite: dropped the now-unnecessary *Liberate disk space*, *Pull foundation image*, and *Define docker helper* steps; kept the Lean branch-check/checkout/move.

YAML validated; needs a self-hosted runner to confirm end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)